### PR TITLE
Safeguard against bad Request args

### DIFF
--- a/webapp/app/utils.py
+++ b/webapp/app/utils.py
@@ -109,3 +109,11 @@ def entity_to_int(s):
         return 6
     else:
         raise Exception(f'Fatal error: {s}')
+
+
+class RequestChecker:
+    """
+    Given a request object with its args, make sure that it is 
+    providing valid arguments.
+    """
+    pass

--- a/webapp/app/utils.py
+++ b/webapp/app/utils.py
@@ -1,6 +1,6 @@
 import numpy as np
 import pandas as pd
-from typing import Dict, Any
+from typing import Dict, Any, List, Tuple
 from sqlalchemy import desc, cast, Float
 from app.models import Address
 
@@ -109,6 +109,82 @@ def entity_to_int(s):
         return 6
     else:
         raise Exception(f'Fatal error: {s}')
+
+
+def to_dict(
+    addr: Address, 
+    table_cols: List[str], 
+    to_remove: List[str] = [], 
+    to_transform: List[Tuple[str, Any]] = [],
+) -> Dict[str, Any]:
+    """
+    Convert a raw row into the form we want to send to the frontend.
+    for `to_transform`, each element is in the tuple form: 
+        (key_to_override_value_of, function to take of the old value)
+    """
+    output: Dict[str, Any] = {  # ignore cluster columns
+        k: getattr(addr, k) for k in table_cols if 'cluster' not in k
+    }
+    output['conf'] = round(output['conf'], 3)
+    del output['meta_data']  # Q: should we keep this?
+
+    for k in to_remove:
+        if k in output:
+            del output[k]
+    for key, func in to_transform:
+        output[key] = func(output[key])
+    return output
+
+
+def default_response() -> Dict[str, Any]:
+    output: Dict[str, Any] = {
+        'data': {
+            'query': {
+                'address': '', 
+                'metadata': {}, 
+                'tornado': {
+                    'exact_match': {},
+                    'gas_price': {},
+                }
+            },
+            'cluster': [],
+            'metadata': {
+                'cluster_size': 0,
+                'num_pages': 0,
+                'page': 0,
+                'limit': 50,
+                'filter_by': {
+                    'min_conf': 0,
+                    'max_conf': 1,
+                    'entity': '*',
+                    'name': '*',
+                },
+                'schema': {
+                    ADDRESS_COL: {
+                        'type': 'string',
+                    },
+                    CONF_COL: {
+                        'type': 'float',
+                        'values': [0, 1],
+                    },
+                    ENTITY_COL: {
+                        'type': 'category',
+                        'values': [
+                            EOA, DEPOSIT, EXCHANGE, DEX, DEFI, ICO_WALLET, MINING],
+                    },
+                    NAME_COL: {
+                        'type': 'string',
+                    },
+                },
+                'sort_default': {
+                    'attribute': ENTITY_COL,
+                    'descending': False
+                }
+            }
+        },
+        'success': 0,
+    }
+    return output
 
 
 class RequestChecker:

--- a/webapp/app/views.py
+++ b/webapp/app/views.py
@@ -53,11 +53,7 @@ def search():
     else:
         desc_sort: bool = bool(
             request.args.get(
-                'descending',
-                False,
-                type=lambda v: v.lower() != 'false',
-            )
-        )
+                'descending', False, type=lambda v: v.lower() != 'false'))
 
     # --- user can filter by columns (* means everything is supported) ---
     filter_min_conf: float = float(request.args.get('filter_min_' + CONF_COL, 0))


### PR DESCRIPTION
We do not want people somehow injecting SQL, or uncovering user data. We add a class `RequestChecker` to go over the arguments in `request` and sanity check them. If things fail when checking address, we bail. If it fails on checking a less important argument, like limit, we go to a default value like 50. 

Also refactored `views.py` to be less crowded by moving some utilities in `utils.py`.