### PR TITLE
Add data on Tornado Addresses and Deposits

### DIFF
--- a/webapp/app/models.py
+++ b/webapp/app/models.py
@@ -63,7 +63,7 @@ class GasPrice(db.Model):
 
 
 class TornadoDeposit(db.Model):
-    __tablename__: str = 'h'
+    __tablename__: str = 'tornado_deposit'
     id: db.Column = db.Column(db.Integer, primary_key = True)
     hash: db.Column = db.Column(db.String(128), index = True, nullable = False)
     transaction_index  = db.Column(db.Integer, nullable = False)

--- a/webapp/app/models.py
+++ b/webapp/app/models.py
@@ -60,3 +60,38 @@ class GasPrice(db.Model):
 
     def __repr__(self) -> str:
         return f'<GasPrice {self.address}>'
+
+
+class TornadoDeposit(db.Model):
+    __tablename__: str = 'h'
+    id: db.Column = db.Column(db.Integer, primary_key = True)
+    hash: db.Column = db.Column(db.String(128), index = True, nullable = False)
+    transaction_index  = db.Column(db.Integer, nullable = False)
+    from_address = db.Column(db.String(128), nullable = False)
+    to_address = db.Column(db.String(128), nullable = False)
+    gas = db.Column(db.Float)
+    gas_price = db.Column(db.Float)
+    block_number = db.Column(db.Integer, nullable = False)
+    block_hash = db.Column(db.String(128), index = True, nullable = False)
+    tornado_cash_address = db.Column(db.String(128), index = True, nullable = False)
+
+    def __repr__(self) -> str:
+        return f'<TornadoDeposit {self.hash}>'
+
+
+class TornadoWithdraw(db.Model):
+    __tablename__: str = 'tornado_withdraw'
+    id: db.Column = db.Column(db.Integer, primary_key = True)
+    hash: db.Column = db.Column(db.String(128), index = True, nullable = False)
+    transaction_index  = db.Column(db.Integer, nullable = False)
+    from_address = db.Column(db.String(128), nullable = False)
+    to_address = db.Column(db.String(128), nullable = False)
+    gas = db.Column(db.Float)
+    gas_price = db.Column(db.Float)
+    block_number = db.Column(db.Integer, nullable = False)
+    block_hash = db.Column(db.String(128), index = True, nullable = False)
+    tornado_cash_address = db.Column(db.String(128), index = True, nullable = False)
+    recipient_address = db.Column(db.String(128), index = True, nullable = False)
+
+    def __repr__(self) -> str:
+        return f'<TornadoWithdraw {self.hash}>'

--- a/webapp/app/static/css/cluster.css
+++ b/webapp/app/static/css/cluster.css
@@ -134,7 +134,15 @@ RESULTS
     width: 100%;
 }
 
+/* tornado info ------------------ */
 
+.tornado-info {
+    background-color: var(--fadedgrey);
+    border-radius: 5px;
+    margin-left: 30px;
+    padding: 15px;
+    width: 100%; 
+}
 
 /* results list ------------------ */
 

--- a/webapp/app/static/js/cluster.js
+++ b/webapp/app/static/js/cluster.js
@@ -22,6 +22,7 @@ $(function () {
     const spinner = $('#spinner');
     const resultIdentifier = $('.result-identifier');
     const queryTable = $('#query-detail-table');
+    const tornadoTable = $('#tornado-detail-table');
 
     let pageResults = []; //stores the results
     let firstInRange = 1;

--- a/webapp/app/static/js/cluster.js
+++ b/webapp/app/static/js/cluster.js
@@ -323,7 +323,7 @@ $(function () {
             .then(function (response) {
                 spinner.removeClass('shown');
                 const { success, data } = response.data;
-                const { cluster, metadata, query } = data;
+                const { cluster, metadata, query, tornado } = data;
                 anonScoreGroup.addClass('shown');
                 const { schema, sort_default } = metadata;
                 setPagination(query.address, metadata);

--- a/webapp/app/static/js/cluster.js
+++ b/webapp/app/static/js/cluster.js
@@ -277,7 +277,7 @@ $(function () {
             const row = $(document.createElement('tr')).addClass('detail-row');
 
             const og_value = obj[attribute];
-            const value = og_value ? og_value : "";
+            const value = (og_value != null) ? og_value : "";
             row.append(`<td>${attribute}</td`);
             row.append(`<td>
                 ${value}

--- a/webapp/app/static/js/cluster.js
+++ b/webapp/app/static/js/cluster.js
@@ -334,6 +334,7 @@ $(function () {
                 setPagination(query.address, metadata);
                 if (firstTime) {
                     setQueryInfo(query);
+                    setTornadoInfo(tornado);
                     setSearchOptions(schema, sort_default);
                 }
                 pageResults = []; //clear 

--- a/webapp/app/static/js/cluster.js
+++ b/webapp/app/static/js/cluster.js
@@ -299,6 +299,11 @@ $(function () {
         populateTable(queryTable, combined, new Set(['metadata', 'address', 'id', 'anonymity_score']));
     }
 
+    function setTornadoInfo(query) {
+        const {summary} = query;
+        populateTable(tornadoTable, summary);
+    }
+
     /**
      * replaces existing page with new updated page of results. 
      * @param {object} query - a dict mapping from query to val. address must be a query key.

--- a/webapp/app/templates/cluster.html
+++ b/webapp/app/templates/cluster.html
@@ -140,6 +140,9 @@
                 <div class="panel-title">
                     TORNADO CASH INFO
                 </div>
+                <div class="panel-sub">
+                    Compromised addresses are deposit addresses that are deemed revealing of identity through the gas price and synchronous transaction reveals.
+                </div>
                 <div id="tornado-detail-table" class="detail-table">
                 </div>
             </div>

--- a/webapp/app/templates/cluster.html
+++ b/webapp/app/templates/cluster.html
@@ -141,7 +141,7 @@
                     TORNADO CASH INFO
                 </div>
                 <div class="panel-sub">
-                    Compromised addresses are deposit addresses that are deemed revealing of identity through the gas price and synchronous transaction reveals.
+                    Compromised addresses are deposit addresses that are deemed revealing of identity through Tutela heuristics.
                 </div>
                 <div id="tornado-detail-table" class="detail-table">
                 </div>

--- a/webapp/app/templates/cluster.html
+++ b/webapp/app/templates/cluster.html
@@ -130,6 +130,15 @@
                 </div>
                 
             </div>
+
+            <div class="tornado-info results-section">
+                <div class="panel-sub">tornado cash statistics</div>
+                <div class="panel-title">
+                    TORNADO CASH INFO
+                </div>
+                <div id="tornado-detail-table" class="detail-table">
+                </div>
+            </div>
             
             <div class="results-section">
         

--- a/webapp/app/utils.py
+++ b/webapp/app/utils.py
@@ -150,10 +150,11 @@ def default_response() -> Dict[str, Any]:
             'query': {
                 'address': '', 
                 'metadata': {}, 
-                'tornado': {
-                    'exact_match': {},
-                    'gas_price': {},
-                }
+            },
+            'tornado': {
+                'summary': {},
+                'exact_match': {},
+                'gas_price': {},
             },
             'cluster': [],
             'metadata': {

--- a/webapp/app/utils.py
+++ b/webapp/app/utils.py
@@ -157,8 +157,8 @@ def default_response() -> Dict[str, Any]:
                     'num_withdraw': 0,
                     'num_compromised': 0,
                 },
-                '_exact_match': {},
-                '_gas_price': {},
+                # '_exact_match': {},
+                # '_gas_price': {},
             },
             'cluster': [],
             'metadata': {

--- a/webapp/app/utils.py
+++ b/webapp/app/utils.py
@@ -157,8 +157,6 @@ def default_response() -> Dict[str, Any]:
                     'num_withdraw': 0,
                     'num_compromised': 0,
                 },
-                # '_exact_match': {},
-                # '_gas_price': {},
             },
             'cluster': [],
             'metadata': {

--- a/webapp/app/utils.py
+++ b/webapp/app/utils.py
@@ -152,9 +152,13 @@ def default_response() -> Dict[str, Any]:
                 'metadata': {}, 
             },
             'tornado': {
-                'summary': {},
-                'exact_match': {},
-                'gas_price': {},
+                'summary': {
+                    'num_deposit': 0,
+                    'num_withdraw': 0,
+                    'num_compromised': 0,
+                },
+                '_exact_match': {},
+                '_gas_price': {},
             },
             'cluster': [],
             'metadata': {

--- a/webapp/app/views.py
+++ b/webapp/app/views.py
@@ -177,13 +177,13 @@ def search():
         deposits: Optional[List[TornadoDeposit]] = \
             TornadoDeposit.query.filter_by(from_address = address).all()
 
-        num_deposit: int = len(deposits.hash.unique())
+        num_deposit: int = len(set([d.hash for d in deposits]))
 
         # find all txs where the recipient_address is the current user
         withdraws: Optional[List[TornadoWithdraw]] = \
             TornadoWithdraw.query.filter_by(recipient_address = address).all()
 
-        num_withdraw: int = len(withdraws.hash.unique())
+        num_withdraw: int = len(set([w.hash for w in withdraws]))
 
         stats: Dict[str, int] = dict(
             num_deposit = num_deposit,

--- a/webapp/app/views.py
+++ b/webapp/app/views.py
@@ -6,7 +6,7 @@ from typing import Dict, Optional, List, Any, Set
 from app import app, w3, ns, known_addresses
 from app.models import Address, ExactMatch, GasPrice
 from app.utils import \
-    safe_int, get_anonymity_score, get_order_command, \
+    get_anonymity_score, get_order_command, \
     entity_to_int, entity_to_str, to_dict, \
     RequestChecker, default_response, \
     NAME_COL, ENTITY_COL, CONF_COL, EOA, DEPOSIT, EXCHANGE

--- a/webapp/app/views.py
+++ b/webapp/app/views.py
@@ -4,7 +4,9 @@ import numpy as np
 from typing import Dict, Optional, List, Any, Set
 
 from app import app, w3, ns, known_addresses
-from app.models import Address, ExactMatch, GasPrice
+from app.models import \
+    Address, ExactMatch, GasPrice, \
+    TornadoDeposit, TornadoWithdraw
 from app.utils import \
     get_anonymity_score, get_order_command, \
     entity_to_int, entity_to_str, to_dict, \
@@ -62,10 +64,8 @@ def search():
     output['data']['query']['address'] = address
     output['data']['metadata']['page'] = page
     output['data']['metadata']['limit'] = size
-    output['data']['metadata']['filter_by']['min_conf'] = checker.get('filter_min_conf')
-    output['data']['metadata']['filter_by']['max_conf'] = checker.get('filter_max_conf')
-    output['data']['metadata']['filter_by']['entity'] = checker.get('filter_entity')
-    output['data']['metadata']['filter_by']['name'] = checker.get('filter_name')
+    for k in output['data']['metadata']['filter_by'].keys():
+        output['data']['metadata']['filter_by'][k] = checker.get(f'filter_{k}')
 
 
     def compute_anonymity_score(
@@ -165,6 +165,15 @@ def search():
 
         return dict(reveal_size=len(history), history=history)
 
+    def query_tornado_stats(address: str) -> Dict[str, Any]:
+        """
+        Given a user address, we want to supply a few statistics:
+
+        1) Number of deposits made to Tornado pools.
+        2) Number of withdraws made to Tornado pools.
+        3) Number of deposits made that are part of a cluster or of a TCash reveal.
+        """
+        pass
 
     if len(address) > 0:
         offset: int = page * size
@@ -301,8 +310,8 @@ def search():
         # Note that this is out of the `Address` existence check
         exact_match_dict: Dict[str, Any] = query_exact_match_heuristic(address)
         gas_price_dict: Dict[str, Any] = query_gas_price_heuristic(address)
-        output['data']['query']['tornado']['exact_match'] = exact_match_dict
-        output['data']['query']['tornado']['gas_price'] = gas_price_dict
+        output['data']['tornado']['exact_match'] = exact_match_dict
+        output['data']['tornado']['gas_price'] = gas_price_dict
 
         # if `addr` doesnt exist, then we assume no clustering
         output['success'] = 1

--- a/webapp/app/views.py
+++ b/webapp/app/views.py
@@ -332,8 +332,8 @@ def search():
         exact_match_dict: Dict[str, Any] = query_exact_match_heuristic(address)
         gas_price_dict: Dict[str, Any] = query_gas_price_heuristic(address)
         # NOTE: _key means it will be ignored in the frontend
-        output['data']['tornado']['_exact_match'] = exact_match_dict
-        output['data']['tornado']['_gas_price'] = gas_price_dict
+        # output['data']['tornado']['_exact_match'] = exact_match_dict
+        # output['data']['tornado']['_gas_price'] = gas_price_dict
 
         # if `addr` doesnt exist, then we assume no clustering
         output['success'] = 1

--- a/webapp/upload_tornado.py
+++ b/webapp/upload_tornado.py
@@ -1,0 +1,44 @@
+"""
+Upload tornado data into PostgreSQL.
+"""
+
+import os
+import psycopg2
+from typing import Any, List
+
+
+def main(args: Any):
+    deposit_csv_path: str = os.path.realpath(args.deposit_csv)
+    withdraw_csv_path: str = os.path.realpath(args.withdraw_csv)
+
+    conn = psycopg2.connect(database = 'tornado', user = 'postgres')
+    cursor = conn.cursor()
+
+    deposit_columns: List[str] = [
+        'hash', 'transaction_index', 'from_address', 'to_address', 'gas',
+        'gas_price', 'block_number', 'block_hash', 'tornado_cash_address'
+    ]
+    cursor.execute(
+        f"COPY tornado_deposit({','.join(deposit_columns)}) FROM '{deposit_csv_path}' DELIMITER ',' CSV HEADER;"
+    )
+    conn.commit()
+
+    withdraw_columns: List[str] = [
+        'hash', 'transaction_index', 'from_address', 'to_address', 'gas',
+        'gas_price', 'block_number', 'block_hash', 'tornado_cash_address',
+        'recipient_address',
+    ]
+    cursor.execute(
+        f"COPY tornado_withdraw({','.join(withdraw_columns)}) FROM '{withdraw_csv_path}' DELIMITER ',' CSV HEADER;"
+    )
+    conn.commit()
+
+
+if __name__ == "__main__":
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument('deposit_csv', type=str)
+    parser.add_argument('withdraw_csv', type=str)
+    args = parser.parse_args()
+
+    main(args)


### PR DESCRIPTION
Summary of the actions taken:

- Add a script `upload_tornado.py` to commit Tornado datasets into PostgreSQL.
- Take a subset of the `lighter_complete...` CSVs as what we will upload into PostgreSQL.
- Added two tables to the Flask database.
- Move the `tornado` field out of `query`, so the second-level fields in response will now be: `query, tornado, cluster, metadata`.
- Add a `summary` field under `tornado` that computes the number of TCash deposits and withdraws made.
- The number of compromised addresses subtracts txs based on gas price and exact match heuristics.
- Tested on `PROD` server.