### PR TITLE
Bug-fixes with regards to the filters on address page

### DIFF
--- a/webapp/app/static/css/cluster.css
+++ b/webapp/app/static/css/cluster.css
@@ -419,7 +419,7 @@ ul.dropdown-menu {
 }
 
 .expand-symbol {
-    font-size: 1.3em;
+    font-size: 0.8em;
 }
 
 .result-identifier {

--- a/webapp/app/static/jsx/address/ClusterResults.jsx
+++ b/webapp/app/static/jsx/address/ClusterResults.jsx
@@ -20,7 +20,7 @@ function NoClusters() {
 
 
 export default function ClusterResults(props) {
-    const { results, loading, sortBy, descendingSort, schema, setSort, getNewResults, paginationData, aliases } = props;
+    const { results, loading, schema, setSort, getNewResults, paginationData, aliases } = props;
     const noResults = results.length == 0;
 
     function Row({ result, idx }) {
@@ -50,7 +50,7 @@ export default function ClusterResults(props) {
                     LINKED ADDRESSES
                 </div>
             </div>
-            <SortAndFilters schema={schema} setSort={setSort} sortBy={sortBy} descendingSort={descendingSort} getNewResults={getNewResults} />
+            <SortAndFilters schema={schema} setSort={setSort} getNewResults={getNewResults} />
             {!noResults && <Pagination paginationData={paginationData} getNewResults={getNewResults} />}
 
             <div >

--- a/webapp/app/static/jsx/address/index.jsx
+++ b/webapp/app/static/jsx/address/index.jsx
@@ -9,6 +9,7 @@ import TornadoInfo from './TornadoInfo';
 import schemaResponse from '../../data/schema';
 import TpoolOverall from './TpoolOverall';
 import TpoolStats from './TpoolStats'
+import { QueryObjContext } from '../components/Contexts';
 
 import ClusterResults from './ClusterResults';
 
@@ -16,7 +17,7 @@ function ClusterPage(props) {
     const { params } = props;
     const inputEl = useRef(null);
 
-    let [queryObj, setQuery] = useState({});
+    let [queryObj, setQuery] = useState({}); //sorts and filters 
     const [inputAddress, setInputAddress] = useState('');
     const [pageResults, setPageResults] = useState([]);
     const [invalid, setInvalid] = useState(false);
@@ -24,7 +25,7 @@ function ClusterPage(props) {
     const [showResultsSection, setShowResultsSection] = useState(false);
     const [loadingCluster, setLoadingCluster] = useState(false);
     const [loadingQuery, setLoadingQuery] = useState(false);
-    const [queryInfo, setQueryInfo] = useState({});
+    const [queryInfo, setQueryInfo] = useState({}); //info about the input 
     const [tornado, setTornado] = useState({});
     const [aliases, setAliases] = useState({});
     const [schema, setSchema] = useState({});
@@ -188,22 +189,26 @@ function ClusterPage(props) {
                             </div>}
                         </>}
                     {searchType === 'other' && <>
-                    {showResultsSection && <div className="results-section">
+                        {showResultsSection && <div className="results-section">
 
-                        <QueryInfo data={queryInfo} loading={loadingQuery} aliases={aliases} />
-                        <TornadoInfo data={tornado} aliases={aliases} />
+                            <QueryInfo data={queryInfo} loading={loadingQuery} aliases={aliases} />
+                            <TornadoInfo data={tornado} aliases={aliases} />
 
-                    </div>}
+                        </div>}
                         {showResultsSection &&
-                            <ClusterResults
-                                paginationData={paginationData}
-                                setSort={setSort}
-                                sortBy={queryObj.sort} descendingSort={queryObj.descending} schema={schema}
-                                results={pageResults}
-                                loading={loadingCluster}
-                                getNewResults={getNewResults}
-                                aliases={aliases}
-                            />}
+                            <QueryObjContext.Provider value={queryObj}>
+                                <ClusterResults
+                                    paginationData={paginationData}
+                                    setSort={setSort}
+                                    schema={schema}
+                                    results={pageResults}
+                                    loading={loadingCluster}
+                                    getNewResults={getNewResults}
+                                    aliases={aliases}
+                                />
+                            </QueryObjContext.Provider>
+
+                        }
                     </>}
 
                 </div >

--- a/webapp/app/static/jsx/address/index.jsx
+++ b/webapp/app/static/jsx/address/index.jsx
@@ -79,7 +79,7 @@ function ClusterPage(props) {
             .then(function (response) {
                 setLoadingQuery(false);
                 setLoadingCluster(false);
-                // response = schemaResponse;
+                // response = example;
                 const { success, data, is_tornado } = response.data;
                 if (is_tornado === 1) {
                     const { query } = data;

--- a/webapp/app/static/jsx/components/Contexts.jsx
+++ b/webapp/app/static/jsx/components/Contexts.jsx
@@ -1,0 +1,3 @@
+import React from 'react'; 
+
+export const QueryObjContext = React.createContext({});

--- a/webapp/app/static/jsx/components/SortAndFilters.jsx
+++ b/webapp/app/static/jsx/components/SortAndFilters.jsx
@@ -1,10 +1,187 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect, useContext, useRef } from 'react';
 import { Dropdown, Accordion, Form, InputGroup, FormControl, } from 'react-bootstrap';
+import { QueryObjContext } from './Contexts';
 
 const CHECKMARK = '\u2713';
 
+/**
+ * FloatBody - allows user to filter via range of something 
+ * @param {*} k: name of that filter option, values: min and max option, getNewResult: rerenders page 
+ * @returns 
+ */
+const FloatBody = ({ k, values, getNewResults }) => {
+    const getFilterParam = (minOrMax, k) => `filter_${minOrMax}_${k}`
 
-export default function SortAndFilters({ schema, descendingSort, sortBy, setSort, getNewResults }) {
+    const [min, max] = values;
+    const [minInvalid, setMinInvalid] = useState(false);
+    const [maxInvalid, setMaxInvalid] = useState(false);
+    const [minVal, setMinVal] = useState(min);
+    const [maxVal, setMaxVal] = useState(max);
+
+    const queryObjContext = useContext(QueryObjContext);
+    const filterMin = queryObjContext[getFilterParam('min', k)];
+    const filterMax = queryObjContext[getFilterParam('max', k)];
+
+    //in case filters were cleared 
+    useEffect(() => {
+        if (filterMin === undefined && filterMax === undefined) {
+            setMinVal(min);
+            setMaxVal(max);
+        }
+    }, [filterMin, filterMax])
+
+
+    const submit = (minOrMax, val) => {
+        if (minOrMax === 'min') {
+            if (val < min) {
+                setMinInvalid(true);
+                return;
+            } else if (minInvalid) {
+                setMinInvalid(false);
+            }
+        }
+        if (minOrMax === 'max') {
+            if (val > max) {
+                setMaxInvalid(true);
+                return;
+            } else if (maxInvalid) {
+                setMaxInvalid(false);
+            }
+        }
+        const key = getFilterParam(minOrMax, k);
+        let obj = { page: 0 };
+        obj[key] = val;
+        getNewResults(false, obj);
+    }
+    return (
+        <Accordion.Body className="dropdown-accordion">
+            <InputGroup hasValidation className="my-input" >
+                <InputGroup.Text >min</InputGroup.Text>
+                <FormControl
+                    value={minVal}
+                    isInvalid={minInvalid}
+                    onChange={(e) => setMinVal(e.target.value)}
+                    onKeyPress={(e) => {
+                        if (e.key !== 'Enter') return;
+                        e.preventDefault();
+                        submit('min', minVal);
+                    }}
+                />
+                <Form.Control.Feedback type="invalid">
+                    Value should be no less than {min}.
+                </Form.Control.Feedback>
+            </InputGroup>
+            <InputGroup hasValidation className="my-input" onSubmit={val => submit('max', val)}>
+                <InputGroup.Text >max</InputGroup.Text>
+                <FormControl
+                    value={maxVal}
+                    isInvalid={maxInvalid}
+                    onChange={e => setMaxVal(e.target.value)}
+                    onKeyPress={(e) => {
+                        if (e.key !== 'Enter') return;
+                        e.preventDefault();
+                        submit('max', maxVal);
+                    }}
+                />
+                <Form.Control.Feedback type="invalid">
+                    Value should be no greater than {max}.
+                </Form.Control.Feedback>
+            </InputGroup>
+        </Accordion.Body>
+    );
+}
+
+/**
+ * CategoryBody - filter option for categorical filter 
+ * @param {*} k: name of that filter option, values: category options, getNewResults: rerenders
+ * @returns 
+ */
+const CategoryBody = ({ k, values, getNewResults }) => {
+
+    const getFilterParam = categoryName => 'filter_' + categoryName; //example: filter_entity 
+
+    //check whether the response used this filter. 
+    const filter = useContext(QueryObjContext)[getFilterParam(k)];
+
+    return (
+        <Accordion.Body className="dropdown-accordion">
+            {values.map((value, idx) =>
+                <Dropdown.Item className={filter === value ? 'selected-dropdown' : ''}
+                    key={idx}
+                    eventKey={value}
+                    onClick={e => {
+                        let obj = { page: 0 };
+                        obj[getFilterParam(k)] = value;
+                        getNewResults(false, obj);
+                    }}>
+                    {value}
+                </Dropdown.Item>)}
+        </Accordion.Body>
+    )
+}
+
+const FilterByName = ({ ogVal, getNewResults }) => {
+    const [val, setVal] = useState(ogVal || '');
+    const inputEl = useRef(null);
+
+    useEffect(() => {
+        //in case filters were cleared 
+        if (ogVal === undefined) {
+            setVal('');
+            inputEl.current.value = '';
+        }
+    }, [ogVal])
+
+    return (
+        <InputGroup  >
+            <FormControl className="specific-result"
+                placeholder="search specific address or name"
+                onChange={(e) => {
+                    e.preventDefault();
+                    setVal(e.target.value);
+                }}
+                onKeyPress={(e) => {
+                    if (e.key !== 'Enter') {
+                        return;
+                    }
+                    getNewResults(false, { page: 0, filter_name: val });
+                }}
+                ref={inputEl}
+            />
+        </InputGroup>
+    );
+}
+
+
+/**
+ * FilterOption - these go into the filter dropdown 
+ * @param {*} entry: name of filter option, idx: index of filter option, getNewResults: rerenders everything 
+ * @returns 
+ */
+const FilterOption = ({ entry, idx, getNewResults }) => {
+    const [key, details] = entry;
+    const [selected, setSelected] = useState(false);
+
+    if (key === 'name' || key === 'address') {
+        return <></>; //ignore these
+    }
+
+    const { type, values } = details;
+
+    return (
+        <Accordion.Item eventKey={idx} className='dropdown-accordion' key={idx}>
+            <Accordion.Header className="dropdown-accordion" onClick={() => setSelected(!selected)}>
+                <div>{key}</div> <div className="expand-symbol">&#x25BC;</div>
+            </Accordion.Header>
+            {type === 'float' && <FloatBody k={key} values={values} getNewResults={getNewResults} />}
+            {type === 'category' && <CategoryBody k={key} values={values} getNewResults={getNewResults} />}
+        </Accordion.Item>
+    );
+}
+
+export default function SortAndFilters({ schema, setSort, getNewResults }) {
+
+    const { descending: descendingSort, filter_name } = useContext(QueryObjContext);
 
     const selectSort = val => {
         if (val === 'descending') {
@@ -19,134 +196,9 @@ export default function SortAndFilters({ schema, descendingSort, sortBy, setSort
 
 
     const getSortOption = (key, idx) => {
+        const sortBy = useContext(QueryObjContext).sort;
         return (
             <Dropdown.Item eventKey={key} className={sortBy === key ? 'selected-dropdown' : ''} key={idx}>{key}</Dropdown.Item>
-        );
-    }
-
-    const FloatBody = ({ k, values }) => {
-        const [min, max] = values;
-        const [minInvalid, setMinInvalid] = useState(false);
-        const [maxInvalid, setMaxInvalid] = useState(false);
-        const [minVal, setMinVal] = useState(min);
-        const [maxVal, setMaxVal] = useState(max);
-
-        const submit = (minOrMax, val) => {
-            if (minOrMax === 'min') {
-                if (val < min) {
-                    setMinInvalid(true);
-                    return;
-                } else if (minInvalid) {
-                    setMinInvalid(false);
-                }
-            }
-            if (minOrMax === 'max') {
-                if (val > max) {
-                    setMaxInvalid(true);
-                    return;
-                } else if (maxInvalid) {
-                    setMaxInvalid(false);
-                }
-            }
-            const key = `filter_${minOrMax}_${k}`;
-            let obj = { page: 0 };
-            obj[key] = val;
-            getNewResults(false, obj);
-        }
-        return (
-            <Accordion.Body className="dropdown-accordion">
-                <InputGroup hasValidation className="my-input" >
-                    <InputGroup.Text >min</InputGroup.Text>
-                    <FormControl
-                        value={minVal}
-                        isInvalid={minInvalid}
-                        onChange={(e) => setMinVal(e.target.value)}
-                        onKeyPress={(e) => {
-                            if (e.key !== 'Enter') return;
-                            e.preventDefault();
-                            submit('min', minVal);
-                        }}
-                    />
-                    <Form.Control.Feedback type="invalid">
-                        Value should be no less than {min}.
-                    </Form.Control.Feedback>
-                </InputGroup>
-                <InputGroup hasValidation className="my-input" onSubmit={val => submit('max', val)}>
-                    <InputGroup.Text >max</InputGroup.Text>
-                    <FormControl
-                        value={maxVal}
-                        isInvalid={maxInvalid}
-                        onChange={e => setMaxVal(e.target.value)}
-                        onKeyPress={(e) => {
-                            if (e.key !== 'Enter') return;
-                            e.preventDefault();
-                            submit('max', maxVal);
-                        }}
-                    />
-                    <Form.Control.Feedback type="invalid">
-                        Value should be no greater than {max}.
-                    </Form.Control.Feedback>
-                </InputGroup>
-            </Accordion.Body>
-        );
-    }
-
-    const CategoryBody = ({ k, values }) => {
-        const [selected, setSelected] = useState(null);
-        return (
-            <Accordion.Body className="dropdown-accordion">
-                {values.map((value, idx) =>
-                    <Dropdown.Item className={selected === value ? 'selected-dropdown' : ''}
-                        key={idx}
-                        eventKey={value}
-                        onClick={e => {
-                            setSelected(value);
-                            let obj = { page: 0 };
-                            obj['filter_' + k] = value;
-                            getNewResults(false, obj);
-                        }}>
-                        {value}
-                    </Dropdown.Item>)}
-            </Accordion.Body>
-        )
-    }
-
-    const FilterOption = ({ entry, idx }) => {
-        const [key, details] = entry;
-        const [selected, setSelected] = useState(false);
-
-        if (key === 'name' || key === 'address') {
-            return <></>; //ignore these
-        }
-
-        const { type, values } = details;
-
-        return (
-            <Accordion.Item eventKey={idx} className='dropdown-accordion' key={idx}>
-                <Accordion.Header className="dropdown-accordion" onClick={() => setSelected(!selected)}>
-                    <div>{key}</div> <div className="expand-symbol">&#x25BC;</div>
-                </Accordion.Header>
-                {type === 'float' && <FloatBody k={key} values={values} />}
-                {type === 'category' && <CategoryBody k={key} values={values} />}
-            </Accordion.Item>
-        );
-    }
-
-    const FilterByName = () => {
-        const [val, setVal] = useState('');
-        return (
-            <InputGroup  >
-                <FormControl className="specific-result"
-                    value={val}
-                    placeholder="search specific address or name"
-                    onChange={(e) => setVal(e.target.value)}
-                    onKeyPress={(e) => {
-                        if (e.key !== 'Enter') return;
-                        e.preventDefault();
-                        getNewResults(false, {page: 0, filter_name: val});
-                    }}
-                />
-            </InputGroup>
         );
     }
 
@@ -173,7 +225,7 @@ export default function SortAndFilters({ schema, descendingSort, sortBy, setSort
 
                 <Dropdown.Menu>
                     <Accordion>
-                        {Object.entries(schema).map((entry, idx) => <FilterOption idx={idx} key={idx} entry={entry} />)}
+                        {Object.entries(schema).map((entry, idx) => <FilterOption idx={idx} key={idx} entry={entry} getNewResults={getNewResults} />)}
                     </Accordion>
                     <Dropdown.Divider />
                     <Dropdown.Item className="flush-right" onClick={() => getNewResults(false, 'clear')} >
@@ -183,7 +235,7 @@ export default function SortAndFilters({ schema, descendingSort, sortBy, setSort
 
             </Dropdown>
 
-            <FilterByName />
+            <FilterByName ogVal={filter_name} getNewResults={getNewResults} />
 
         </div>
     );

--- a/webapp/app/static/jsx/components/SortAndFilters.jsx
+++ b/webapp/app/static/jsx/components/SortAndFilters.jsx
@@ -124,7 +124,7 @@ export default function SortAndFilters({ schema, descendingSort, sortBy, setSort
         return (
             <Accordion.Item eventKey={idx} className='dropdown-accordion' key={idx}>
                 <Accordion.Header className="dropdown-accordion" onClick={() => setSelected(!selected)}>
-                    <div>{key}</div> <div className="expand-symbol">{selected ? '-' : '+'}</div>
+                    <div>{key}</div> <div className="expand-symbol">&#x25BC;</div>
                 </Accordion.Header>
                 {type === 'float' && <FloatBody k={key} values={values} />}
                 {type === 'category' && <CategoryBody k={key} values={values} />}

--- a/webapp/app/static/jsx/components/SortAndFilters.jsx
+++ b/webapp/app/static/jsx/components/SortAndFilters.jsx
@@ -198,7 +198,7 @@ export default function SortAndFilters({ schema, setSort, getNewResults }) {
     const getSortOption = (key, idx) => {
         const sortBy = useContext(QueryObjContext).sort;
         return (
-            <Dropdown.Item eventKey={key} className={sortBy === key ? 'selected-dropdown' : ''} key={idx}>{key}</Dropdown.Item>
+            <Dropdown.Item eventKey={key} className={sortBy === key ? 'selected-dropdown' : ''} key={idx}>{key === 'conf' ? 'confidence' : key}</Dropdown.Item>
         );
     }
 

--- a/webapp/app/utils.py
+++ b/webapp/app/utils.py
@@ -10,7 +10,7 @@ from sqlalchemy import or_, and_
 # CONSTS for schema
 ADDRESS_COL: str = 'address'
 ENTITY_COL: str = 'entity'
-CONF_COL: str = 'confidence'
+CONF_COL: str = 'conf'
 NAME_COL: str = 'name'
 HEURISTIC_COL: str = 'heuristic'
 # --


### PR DESCRIPTION
Address 4 bugs:
1) sometimes the icon + and - would be incorrect in the dropdown filter menu, particularly if the user had selected a filter and didn't collapse that filter option. Now, that problem is avoided by changing the icon to a down arrow. 
2) the filter dropdown wouldn't highlight the selected filters. Now, it highlights whatever the user has selected, and it also will de-highlight if the user clears all filters. 
3) filter_name (where you can type an address or ens) now works and clears (when user clears filters) as expected. 
4) sorting by confidence stopped working bc of a mismatch of parameter values (conf vs confidence). fixed. 
