### PR TITLE
Bugfix: Non-DAR addresses should be shown for Diff2Vec.

### DIFF
--- a/webapp/app/views.py
+++ b/webapp/app/views.py
@@ -88,20 +88,16 @@ def istornado():
 
 @app.route('/utils/gettornadopools', methods=['GET'])
 def get_tornado_pools():
-
     pools = []
-
-    for index, pool in tornado_pools.iterrows():
-        amount, currency = pool.tags.strip().split()
+    for _, pool in tornado_pools.iterrows():
+        # amount, currency = pool.tags.strip().split()
         pools.append({
             'address': pool.address, 
             'name': pool.tags,
         })
 
     output: Dict[str, Any] = {
-        'data': {
-            'pools': pools
-        },
+        'data': {'pools': pools},
         'success': 1,
     }
     response: str = json.dumps(output) 


### PR DESCRIPTION
The whole point of adding Diff2Vec was to find clusters for addresses not showing up in DAR. Unfortunately, the current design does not query Diff2Vec when address does not have DAR clusters.